### PR TITLE
Update Java and dependencies to latest versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,20 +30,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+    #  uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -66,13 +57,13 @@ jobs:
     #- run: |
     #   make bootstrap
     #   make release
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: '21'
+        distribution: 'temurin'
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -81,4 +72,4 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v3
+    #  uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -72,4 +72,4 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
 			<version>3.17.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.12.0</version>
+		</dependency>
+		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.17.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- Elasticsearch -->
-		<elasticsearch.version>7.17.26</elasticsearch.version>
-		<elasticsearch.httpclient.version>7.17.26</elasticsearch.httpclient.version>
+		<elasticsearch.version>7.6.2</elasticsearch.version>
+		<elasticsearch.httpclient.version>7.6.2</elasticsearch.httpclient.version>
 	</properties>
 	<build>
 		<resources>
@@ -212,12 +212,12 @@
 		<dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.1.2</version>
+            <version>4.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-stream</artifactId>
-            <version>4.1.2</version>
+            <version>4.0.7</version>
         </dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- Elasticsearch -->
-		<elasticsearch.version>7.6.2</elasticsearch.version>
-		<elasticsearch.httpclient.version>7.6.2</elasticsearch.httpclient.version>
+		<elasticsearch.version>7.17.26</elasticsearch.version>
+		<elasticsearch.httpclient.version>7.17.26</elasticsearch.httpclient.version>
 	</properties>
 	<build>
 		<resources>
@@ -38,15 +38,15 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.13.0</version>
 				<configuration>
-					<release>11</release>
+					<release>21</release>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>source-jar</id>
@@ -59,7 +59,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.7.1</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
@@ -85,7 +85,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.10.1</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -127,13 +127,15 @@
 				</executions>
 			</plugin>
 		</plugins>
-		<extensions>
+		<!-- Temporarily commented out due to Maven resolution issues
+	<extensions>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-ftp</artifactId>
-				<version>3.3.4</version>
+				<version>3.5.3</version>
 			</extension>
 		</extensions>
+	-->
 	</build>
 
 	<distributionManagement>
@@ -183,44 +185,44 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.14</version>
+			<version>1.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.12</version>
+			<version>4.5.14</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.4.13</version>
+			<version>4.4.16</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.30</version>
+			<version>1.7.36</version>
 		</dependency>
 		<dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.7</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-stream</artifactId>
-            <version>4.0.7</version>
+            <version>4.1.2</version>
         </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -233,7 +235,7 @@
 		<dependency>
 			<groupId>org.codelibs</groupId>
 			<artifactId>corelib</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codelibs</groupId>
@@ -244,17 +246,17 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.7</version>
+			<version>2.24.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.13.2</version>
+			<version>2.24.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.lmax</groupId>
 			<artifactId>disruptor</artifactId>
-			<version>3.4.2</version>
+			<version>4.0.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/codelibs/empros/agent/operation/rest/RestApiOperation.java
+++ b/src/main/java/org/codelibs/empros/agent/operation/rest/RestApiOperation.java
@@ -306,10 +306,10 @@ public class RestApiOperation implements Operation {
                     jsonBuf.append(',');
                 }
                 jsonBuf.append('\"');
-                jsonBuf.append(StringEscapeUtils.escapeJavaScript(entry
+                jsonBuf.append(StringEscapeUtils.escapeEcmaScript(entry
                         .getKey()));
                 jsonBuf.append("\":\"");
-                jsonBuf.append(StringEscapeUtils.escapeJavaScript(entry
+                jsonBuf.append(StringEscapeUtils.escapeEcmaScript(entry
                         .getValue().toString().replace("\'", "")));
                 jsonBuf.append('\"');
             }

--- a/src/main/java/org/codelibs/empros/agent/operation/rest/RestApiOperation.java
+++ b/src/main/java/org/codelibs/empros/agent/operation/rest/RestApiOperation.java
@@ -26,7 +26,7 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/src/main/java/org/codelibs/empros/agent/watcher/file/FileEventFilter.java
+++ b/src/main/java/org/codelibs/empros/agent/watcher/file/FileEventFilter.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codelibs.empros.agent.event.Event;
 import org.codelibs.empros.agent.event.EventFilter;
 import org.codelibs.empros.agent.util.PropertiesUtil;

--- a/src/main/java/org/codelibs/empros/agent/watcher/file/FileWatcher.java
+++ b/src/main/java/org/codelibs/empros/agent/watcher/file/FileWatcher.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.empros.agent.event.EventManager;
 import org.codelibs.empros.agent.util.PropertiesUtil;


### PR DESCRIPTION
- Upgrade Java from 11 to 21
- Update maven-compiler-plugin to 3.13.0 for Java 21 support
- Update Maven plugins:
  - maven-source-plugin: 3.2.1 → 3.3.1
  - maven-assembly-plugin: 3.3.0 → 3.7.1
  - maven-javadoc-plugin: 3.2.0 → 3.10.1
- Update dependencies to latest versions:
  - commons-lang 2.6 → commons-lang3 3.17.0
  - commons-codec: 1.14 → 1.17.1
  - httpclient: 4.5.12 → 4.5.14
  - httpcore: 4.4.13 → 4.4.16
  - slf4j-log4j12: 1.7.30 → 1.7.36
  - twitter4j: 4.0.7 → 4.1.2
  - junit: 4.13.1 → 4.13.2
  - elasticsearch: 7.6.2 → 7.17.26
  - corelib: 0.5.4 → 0.5.5
  - log4j: 2.7/2.13.2 → 2.24.3 (unified versions)
  - disruptor: 3.4.2 → 4.0.0
- Temporarily comment out wagon-ftp extension due to Maven resolution issues